### PR TITLE
Updated PostgreSQL doc to indicate the service is running by default.

### DIFF
--- a/source/docs/databases/postgresql.md
+++ b/source/docs/databases/postgresql.md
@@ -4,6 +4,8 @@ title: PostgreSQL
 category: Databases
 ---
 
+PostgreSQL is running on the default port of 5432.
+
 Credentials for using PostgreSQL are available in environment variables listed below:
 
 <table class="table table-striped table-bordered">
@@ -25,15 +27,18 @@ Credentials for using PostgreSQL are available in environment variables listed b
   </tbody>
 </table>
 
-If you need to create a PostgreSQL database manually, you can use the following
-command:
+If your application doesn't create it's own database as part of the start-up 
+process, you can create a PostgreSQL database manually. Adding the following
+command to your [build
+commands](/docs/customizing-build-commands.html) will 
+create a PostgreSQL database:
 
 ```bash
 createdb test_db -U $DATABASE_POSTGRESQL_USERNAME
 ```
 
-Note that the `createdb` command doesn't require password, since PostgeSQL
-doesn't require password for accessing a database that belongs to the PosgreSQL
+Note that the `createdb` command doesn't require password, since PostgreSQL
+doesn't require password for accessing a database that belongs to the PostgreSQL
 user that has the same name as host operating system user, by default.
 
 ### Executing Postgres commands


### PR DESCRIPTION
Clarified this a little. It wasn't immediately clear that Postgres was available 'by default' in the build environment.