### PR TITLE
Spell "Golang" on the Go page a few times.

### DIFF
--- a/source/docs/go-continuous-integration.md.erb
+++ b/source/docs/go-continuous-integration.md.erb
@@ -1,11 +1,11 @@
 ---
 layout: post
-title: Go Continuous Integration
+title: Go (Golang) Continuous Integration
 alias: docs/go.html
 category: Languages
 ---
 
-Setting up a Go project on Semaphore is easy. The first time you add a Go
+Setting up a Golang project on Semaphore is easy. The first time you add a Go
 project, Semaphore will analyze it and propose some frequently used build
 commands to speed up the setup process. If needed, these commands can be
 [customized](/docs/customizing-build-commands.html) to better suit your needs.


### PR DESCRIPTION
People search for it but can't find.