### PR TITLE
Read ruby version from Gemfile

### DIFF
--- a/source/docs/languages/ruby/switching-ruby-version-on-specific-branch.md.erb
+++ b/source/docs/languages/ruby/switching-ruby-version-on-specific-branch.md.erb
@@ -10,4 +10,10 @@ Add a new [build command](/docs/customizing-build-commands.html) that will set t
 if [ "$BRANCH_NAME" = "ruby-2" ]; then rbenv local 2.0.0-p247 ; fi
 ```
 
+Another option is to add a [build command](/docs/customizing-build-commands.html) that reads and sets the ruby version from the first line of the Gemfile:
+
+```bash
+if [[ $(head -n 1 Gemfile) =~ ([[:digit:]].[[:digit:]].[[:digit:]](-p[[:digit:]]+)?) ]]; then echo "Setting rbenv to version ${BASH_REMATCH[1]}" && rbenv local ${BASH_REMATCH[1]}; else echo "Unable to parse ruby version form Gemfile"; fi
+```
+
 Current package versions are listed on the [Supported application stack](/docs/supported-stack.html) page.


### PR DESCRIPTION
This oneliner parses the ruby version from the Gemfile using a regex. When it can't be parsed, the project specific version is used. This saved me a lot of time and I think it is time to share it with the community.