### PR TITLE
Updated URLs to PHP packages

### DIFF
--- a/data/package_versions.yml
+++ b/data/package_versions.yml
@@ -29,6 +29,7 @@ chromedriver:
 composer:
   name: "Composer"
   hide_on_stack_table: true
+  url: "https://getcomposer.org/"
 
 docker:
   name: "Docker"
@@ -199,10 +200,12 @@ nvm:
 pear:
   name: "PEAR"
   hide_on_stack_table: true
+  url: "https://pear.php.net/"
 
 pecl:
   name: "PECL"
   hide_on_stack_table: true
+  url: "https://pecl.php.net/"
 
 phantomjs:
   name: "PhantomJS"
@@ -229,6 +232,7 @@ php:
 phpbrew:
   name: "phpbrew"
   hide_on_stack_table: true
+  url: "http://phpbrew.github.io/phpbrew/"
 
 phpunit:
   name: "PHPunit"


### PR DESCRIPTION
Some of the outbound links on https://semaphoreci.com/docs/languages/php/php-support-on-semaphore.html were broken as the PHP packages referenced were missing their URL values.