### PR TITLE
Change title of scheduling builds docs page

### DIFF
--- a/source/docs/index.html.erb
+++ b/source/docs/index.html.erb
@@ -120,7 +120,7 @@
     <li><a href="/docs/set-high-priority-branches.html">Set high priority branches</a></li>
     <li><a href="/docs/set-queued-builds-cancellation-strategy.html">Set queued builds cancellation strategy</a></li>
     <li><a href="/docs/turn-off-automatic-testing-of-new-branches.html">Turn off automatic testing of new branches</a></li>
-    <li><a href="/docs/scheduling-builds.html">Scheduling builds</a></li>
+    <li><a href="/docs/scheduling-builds.html">Scheduling daily and hourly builds</a></li>
   </ul>
 
   <h3>Managing dependencies</h3>

--- a/source/docs/scheduling-builds.md.erb
+++ b/source/docs/scheduling-builds.md.erb
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Scheduling builds
+title: Scheduling daily and hourly builds
 category: Adapting Semaphore to your workflow
 ---
 


### PR DESCRIPTION
This breaks existing links to this page.

Should I keep the file name and change only the title?