### PR TITLE
Update deploying-to-aws-elastic-beanstalk.md

### DIFF
--- a/source/docs/deploying-to-aws-elastic-beanstalk.md
+++ b/source/docs/deploying-to-aws-elastic-beanstalk.md
@@ -105,11 +105,12 @@ alt="Ready to deploy" class="img-responsive img-bordered">
 Happy building!
 
 ## Example AWS IAM policy
+
 This example shows a policy which provides Semaphore with access to manage your
 Elastic Beanstalk applications and environments. [This
 section](http://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-using.html#create-managed-policy-console)
 of AWS documentation explains how to create a custom policy. You can copy the
-policy shown below.
+policy shown below, but you must update the `[region]` and `[user-or-group-id]` placeholders accordingly for your configuration.
 
 ```javascript
 {
@@ -158,7 +159,7 @@ policy shown below.
                 "cloudformation:UpdateStack"
             ],
             "Resource": [
-                "arn:aws:cloudformation:[region]:[user-id]:*"
+                "arn:aws:cloudformation:[region]:[user-or-group-id]:*"
             ]
         },
         {
@@ -198,7 +199,7 @@ policy shown below.
                 "sns:GetTopicAttributes",
                 "sns:ListSubscriptionsByTopic"
             ],
-            "Resource": "arn:aws:sns:[region]:[user-id]:*"
+            "Resource": "arn:aws:sns:[region]:[user-or-group-id]:*"
         }
     ]
 }


### PR DESCRIPTION
* Point out that the policy needs editing before it is viable
* Update `[user-id]` to `[user-or-group-id]` so that it's more obvious to AWS newbs like me that you could also use an IAM group here rather than a user.