### PR TITLE
Update change log and packages list for platform update 1702

### DIFF
--- a/data/package_versions.yml
+++ b/data/package_versions.yml
@@ -20,7 +20,7 @@ cassandra:
 
 chrome:
   name: "Chrome"
-  version: "55.0.2883.100"
+  version: "56.0.2924.87"
   url: "http://www.google.com/chrome/browser/index.html"
 
 chromedriver:
@@ -59,7 +59,7 @@ elixir:
     - "1.1.1"
     - "1.2.6"
     - "1.3.4"
-    - "1.4.0"
+    - "1.4.2"
   default:
     - "1.2.6"
   url: "/docs/elixir.html"
@@ -78,10 +78,18 @@ firefox:
   versions:
     - "34.0"
     - "38.8.0 ESR"
-    - "45.6.0 ESR"
+    - "45.7.0 ESR"
   default:
     - "34.0"
   url: "/docs/firefox.html"
+
+geckodriver:
+  name: "geckodriver"
+  versions:
+    - "0.14.0"
+  default:
+    - "0.14.0"
+  url: "https://github.com/mozilla/geckodriver"
 
 gcc:
   name: "gcc"
@@ -97,7 +105,8 @@ go:
     - "1.4.3"
     - "1.5.4"
     - "1.6.4"
-    - "1.7.4"
+    - "1.7.5"
+    - "1.8"
   default:
     - "1.4.3"
   url: "/docs/go.html"
@@ -156,7 +165,7 @@ memcached:
 
 mongodb:
   name: "MongoDB"
-  version: "3.4.1"
+  version: "3.4.2"
   url: "/docs/databases/mongodb.html"
 
 mysql:
@@ -177,7 +186,7 @@ node:
     - "4.4.7"
     - "4.5.0"
     - "4.6.2"
-    - "4.7.2"
+    - "4.7.3"
     - "5.0.0"
     - "5.1.1"
     - "5.2.0"
@@ -191,10 +200,12 @@ node:
     - "6.2.2"
     - "6.3.1"
     - "6.6.0"
-    - "6.9.4"
+    - "6.9.5"
+    - "6.10.0"
     - "7.1.0"
     - "7.3.0"
     - "7.4.0"
+    - "7.6.0"
   default:
     - "4.6.2"
   url: "/docs/javascript.html"
@@ -235,9 +246,9 @@ php:
     - "5.3.29"
     - "5.4.45"
     - "5.5.38"
-    - "5.6.29"
-    - "7.0.14"
-    - "7.1.0"
+    - "5.6.30"
+    - "7.0.16"
+    - "7.1.2"
   default:
     - "5.6.28"
   url: "/docs/php.html"
@@ -301,7 +312,7 @@ rbenv:
 
 redis:
   name: "Redis"
-  version: "3.0.6"
+  version: "3.2.8"
   url: "http://redis.io/"
 
 rethinkdb:
@@ -316,6 +327,7 @@ ruby:
     - "2.3.3"
     - "2.3.1"
     - "2.3.0"
+    - "2.2.6"
     - "2.2.5"
     - "2.2.4"
     - "2.2.3"
@@ -377,6 +389,6 @@ wkhtmltopdf:
 
 yarn:
   name: "Yarn"
-  version: "0.19.1"
+  version: "0.20.3"
   url: "https://yarnpkg.com/en/docs/install-ci#semaphore-tab"
   hide_on_stack_table: true

--- a/source/docs/platform-changelog.md
+++ b/source/docs/platform-changelog.md
@@ -6,12 +6,13 @@ category: The Semaphore platform
 
 Current package versions are listed on the [Supported application stack](/docs/supported-stack.html) page.
 
-### v1702 - 2017-02-28 (planned)
+### v1702 - 2017-02-28
 ```
 - additions
   - geckodriver 0.14.0
   - go 1.8
-  - node.js 7.5.0
+  - node.js 7.6.0
+  - node.js 6.10.0
   - ruby 2.2.6
 - upgrades
   - elixir 1.4.0 -> 1.4.2


### PR DESCRIPTION
Add new software versions to package_versions.yml;
add Node.js 7.6.0 and 6.10.0;
remove (planned) from title;
add geckodriver 0.14.0 to packages_versions.yml.