### PR TITLE
TOC

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
-    redcarpet (3.0.0)
+    redcarpet (3.4.0)
     rouge (0.3.10)
       thor
     ruby-hmac (0.4.0)

--- a/config.rb
+++ b/config.rb
@@ -9,6 +9,30 @@ require "raml_parser"
 require "./source/docs_renderer"
 require "./source/api_v2"
 
+module DocsHelpers
+  def toc
+    content = ::File.read(current_page.source_file)
+
+    # remove YAML frontmatter
+    content = content.gsub(/^(---\s*\n.*?\n?)^(---\s*$\n?)/m,'')
+
+    markdown = Redcarpet::Markdown.new(
+      Redcarpet::Render::HTML_TOC.new(nesting_level: 3)
+    )
+    markdown.render(content)
+
+# > <ol type="i">
+# >   <li>Constraints</li>
+# >   <li>Authentication</li>
+# >   <li>Errors</li>
+# >   <li>Pagination</li>
+# >   <li>Stability</li>
+# > </ol>
+  end
+end
+
+helpers DocsHelpers
+
 set :markdown_engine, :redcarpet
 set :markdown, :with_toc_data => true, :fenced_code_blocks => true, :smartypants => true, :tables => true, :renderer => DocsRenderer
 activate :syntax #https://github.com/middleman/middleman-syntax

--- a/config.rb
+++ b/config.rb
@@ -7,29 +7,8 @@
 require "raml_parser"
 
 require "./source/docs_renderer"
+require "./source/docs_helpers"
 require "./source/api_v2"
-
-module DocsHelpers
-  def toc
-    content = ::File.read(current_page.source_file)
-
-    # remove YAML frontmatter
-    content = content.gsub(/^(---\s*\n.*?\n?)^(---\s*$\n?)/m,'')
-
-    markdown = Redcarpet::Markdown.new(
-      Redcarpet::Render::HTML_TOC.new(nesting_level: 3)
-    )
-    markdown.render(content)
-
-# > <ol type="i">
-# >   <li>Constraints</li>
-# >   <li>Authentication</li>
-# >   <li>Errors</li>
-# >   <li>Pagination</li>
-# >   <li>Stability</li>
-# > </ol>
-  end
-end
 
 helpers DocsHelpers
 

--- a/config.rb
+++ b/config.rb
@@ -10,11 +10,10 @@ require "./source/docs_renderer"
 require "./source/api_v2"
 
 set :markdown_engine, :redcarpet
-set :markdown, :fenced_code_blocks => true, :smartypants => true, :tables => true, :renderer => DocsRenderer
+set :markdown, :with_toc_data => true, :fenced_code_blocks => true, :smartypants => true, :tables => true, :renderer => DocsRenderer
 activate :syntax #https://github.com/middleman/middleman-syntax
 
 activate :sitemap, :hostname => "https://semaphoreci.com"
-
 activate :alias
 
 #Activate sync extension

--- a/source/api_v2.rb
+++ b/source/api_v2.rb
@@ -16,6 +16,16 @@ module ApiV2
     ].flatten
   end
 
+  def self.toc(routes)
+    list = routes.map do |route|
+      href = route.description.split(" ").map(&:downcase).join("-")
+
+      "<li><a href='##{href}'>#{route.description}</a></li>"
+    end
+
+    "<ol type='i'>#{list.join("\n")}</ol>"
+  end
+
   def self.request_table(request)
     header = [
       ["Name", "Type", "Required", "Example"],

--- a/source/docs/api_v2_overview.md.erb
+++ b/source/docs/api_v2_overview.md.erb
@@ -9,13 +9,7 @@ v2. If you have any problems or requests please contact [support](https://semaph
 
 The root of the API is [https://api.semaphoreci.com/v2](https://api.semaphoreci.com/v2).
 
-<ol type="i">
-  <li>Constraints</li>
-  <li>Authentication</li>
-  <li>Errors</li>
-  <li>Pagination</li>
-  <li>Stability</li>
-</ol>
+<%= toc %>
 
 ### Constraints
 

--- a/source/docs/api_v2_resource.md.erb
+++ b/source/docs/api_v2_resource.md.erb
@@ -7,11 +7,7 @@ Stability: `prototype`
 
 <% content_for :api_v2_title, resource.display_name %>
 
-<ol type="i">
-  <% ApiV2.sorted_routes(resource).each do |route| %>
-    <li><%= route.description %></li>
-  <% end %>
-</ol>
+<%= ApiV2.toc(ApiV2.sorted_routes(resource)) %>
 
 <% ApiV2.sorted_routes(resource).each do |route| %>
 

--- a/source/docs_helpers.rb
+++ b/source/docs_helpers.rb
@@ -1,0 +1,16 @@
+module DocsHelpers
+  def toc
+    content = ::File.read(current_page.source_file)
+
+    # remove YAML frontmatter
+    content = content.gsub(/^(---\s*\n.*?\n?)^(---\s*$\n?)/m,'')
+
+    markdown = Redcarpet::Markdown.new(
+      Redcarpet::Render::HTML_TOC.new(nesting_level: 3)
+    )
+
+    html_list = markdown.render(content)
+
+    html_list.gsub("<ul>", "<ol type='i'>").gsub("</ul>", "</ol>")
+  end
+end

--- a/source/docs_renderer.rb
+++ b/source/docs_renderer.rb
@@ -1,6 +1,12 @@
 require "cgi"
 
 class DocsRenderer < Redcarpet::Render::HTML
+  def initialize(extensions = {})
+    super({
+      :with_toc_data => true
+    }.merge(extensions))
+  end
+
   def block_quote(quote)
     %(<blockquote cite="http://developer.mozilla.org" class="mh0 ph4 pv1 f5 lh-loose bl b--green bw2 black-70 bg-near-white">#{escape_html(quote)}</blockquote>)
   end


### PR DESCRIPTION
Now you can place `<%= toc %>` in any markdown document to generate
table of content that links to subtitles on the page.