### PR TITLE
Add environment variable DEPLOY_AUTHOR_NAME

### DIFF
--- a/source/docs/available-environment-variables.md
+++ b/source/docs/available-environment-variables.md
@@ -116,6 +116,10 @@ Variables available only during deployment:
       <td>Eg. staging</td>
     </tr>
     <tr>
+      <td>DEPLOY_AUTHOR_NAME</td>
+      <td>Semaphore username or commit author</td>
+    </tr>
+    <tr>
       <td>HEROKU_API_KEY</td>
       <td>Eg. 12139243 - when deploying to Heroku</td>
     </tr>


### PR DESCRIPTION
The DEPLOY_AUTHOR_NAME environment variable is available for every new deployment.
When deployment was triggered manually from UI, Semaphore will assign Semaphore username to this variable. Alternatively, in a case of an automatic deployment its value will match commit's author name. 