### PR TITLE
Replace THREAD env vars with new JOB equivalents.

### DIFF
--- a/source/docs/available-environment-variables.md
+++ b/source/docs/available-environment-variables.md
@@ -62,15 +62,15 @@ Before running your build or deploy, Semaphore exports the following environment
       <td>Eg. rastasheep/my_project</td>
     </tr>
     <tr>
-      <td>SEMAPHORE_THREAD_RESULT</td>
+      <td>SEMAPHORE_JOB_RESULT</td>
       <td>Eg. failed</td>
     </tr>
     <tr>
-      <td>SEMAPHORE_CURRENT_THREAD</td>
+      <td>SEMAPHORE_CURRENT_JOB</td>
       <td>Eg. 1</td>
     </tr>
     <tr>
-      <td>SEMAPHORE_THREAD_COUNT</td>
+      <td>SEMAPHORE_JOB_COUNT</td>
       <td>Eg. 4</td>
     </tr>
     <tr>


### PR DESCRIPTION
We're continuing to export `*THREAD*` for the time being too but we've moved on in terminology.