### PR TITLE
Quote correction

### DIFF
--- a/source/docs/shared-configurations.md
+++ b/source/docs/shared-configurations.md
@@ -87,7 +87,7 @@ export ENV_VAR_CONTENT=<content>
 
 curl -X POST \
      -H "Authorization: Token ${AUTH_TOKEN}" \
-     -d "{ \"name\" : \"${ENV_VAR_NAME}\" , \"content\" : \"${ENV_VAR_CONTENT}\" }' \
+     -d "{ \"name\" : \"${ENV_VAR_NAME}\" , \"content\" : \"${ENV_VAR_CONTENT}\" }" \
      "https://api.semaphoreci.com/v2/shared_configs/${SHARED_CONFIG_ID}/env_vars"
 ```
 


### PR DESCRIPTION
Replaced the incorrect single quote, with the correct double quote.

If you tried to run the command as was, it would not work due to the quote mismatch.