### PR TITLE
Replace barcode with QR code

### DIFF
--- a/source/docs/two-step-verification.md.erb
+++ b/source/docs/two-step-verification.md.erb
@@ -17,7 +17,7 @@ can choose the authenticator app for your phone and install it.
 
 <img src="/docs/assets/img/two-step-verification/enable.png" class="img-responsive">
 
-With an authenticator app, you scan a barcode, and the app connects with
+With an authenticator app, you scan a QR code, and the app connects with
 the Semaphore website to verify itself. It then displays a six-digit code,
 which you will need to enter within a limited time frame. When the time runs out,
 the app will generate a new code. Once you have successfully verified the code,


### PR DESCRIPTION
When Semaphore users enable 2FA verification, they are asked to scan QR code, not barcode.