### PR TITLE
Adding note related to 2FA codes

### DIFF
--- a/source/docs/two-step-verification.md.erb
+++ b/source/docs/two-step-verification.md.erb
@@ -43,12 +43,6 @@ Go to your [account settings](https://semaphoreci.com/users/edit) and click on
 verification code generated through the authenticator app, and then select
 "Disable 2-step verification".
 
-In case you'v lost access to the authenticator app, you can also disable 2-step
+In case you've lost access to the authenticator app, you can also disable 2-step
 verification using backup recovery codes. Just follow the "Use backup recovery
 codes" link, enter a recovery code and 2-step verification will be disabled.
-
-
-
-
-
-

--- a/source/docs/two-step-verification.md.erb
+++ b/source/docs/two-step-verification.md.erb
@@ -23,6 +23,12 @@ which you will need to enter within a limited time frame. When the time runs out
 the app will generate a new code. Once you have successfully verified the code,
 two step verification will be turned on for your account.
 
+ __Note:__
+Each time you are asked to enter your authentication code, visit
+the initially chosen application. There you will find 
+needed authentication code. Alternatively, you can enter one of your recovery
+codes.
+
 ### What to do if you lose access to your phone
 
 Once you turn on two-step verification, Semaphore will generate the recovery codes


### PR DESCRIPTION
Sometimes, users might get confused while looking for the 2FA code needed for log in. This edit will remind them that the codes can be found in of previously installed code generator apps