### PR TITLE
Increase timeout interval to 60 secs

### DIFF
--- a/script/link-checker.rb
+++ b/script/link-checker.rb
@@ -36,8 +36,8 @@ options = {
   :typhoeus =>
   {
     :followlocation => true,
-    :connecttimeout => 10,
-    :timeout => 30
+    :connecttimeout => 30,
+    :timeout => 60
   }
 }
 


### PR DESCRIPTION
We have noticed that recent builds are failing due to the timeout error while checking external URLs. 