### PR TITLE
Test Booster Gem

### DIFF
--- a/source/docs/boosters-in-action.md.erb
+++ b/source/docs/boosters-in-action.md.erb
@@ -6,10 +6,21 @@ category: Boosters
 
 <%= toc %>
 
+### Test Boosters Gem
+
+The [Test Boosters](https://github.com/renderedtext/test-boosters) gem is an
+open source test runner that runs your tests in multiple test jobs. It is used
+on Semaphore to support the execution of boosted builds. The Test Booster gem
+comes preinstalled in Semaphore boxes.
+
+If you notice any issues with the test booster gem, please report it as an issue
+on the [GitHub repository](https://github.com/renderedtext/test-boosters/issues).
+
+We are also glad to receive contributions via
+[pull requests](https://github.com/renderedtext/test-boosters/pulls).
+
 ### Boosters for RSpec
 
 ### Boosters for Cucumber
-
-### Test Boosters gem
 
 ### Troubleshooting


### PR DESCRIPTION
Moved the section to the top, as the test booster gem will be referenced in the Boosters for RSpec and Boosters for Cucumber sections.