### PR TITLE
Wrong 2fa code account unlocking explained

### DIFF
--- a/source/docs/unlocking-the-account.md
+++ b/source/docs/unlocking-the-account.md
@@ -4,6 +4,8 @@ title: Unlocking the account
 category: Account
 ---
 
+### Wrong password account lock
+
 In the top right corner of your Semaphore CI homepage you will find "Log in" button.
 If, by any reason, you enter wrong password 5 times in a row, your account will
 be locked due to an excessive number of unsuccessful log in attempts. In order
@@ -13,3 +15,10 @@ unlocking the account.
  __Note:__
 If you’re still not sure about your old password, we suggest that you change it
 right after unlocking the account.
+
+### Wrong Two-Step Verification code (2FA code) account lock
+
+If you've enabled 2-step verification for your Semaphore account, each time you
+log in, you will be asked to enter a new code provided by the [preselected mobile application](/docs/two-step-verification.html).
+Same as with the wrong password, your account will be locked if you enter wrong
+2FA code 5 times in a row. In that case, please contact us at <mailto:support@semaphoreci.com>.


### PR DESCRIPTION
Explained process of account unlocking after being locked because of 5 wrong 2fa code entries