### PR TITLE
Updating Chrome in Semaphore environment

### DIFF
--- a/source/categories/_build_troubleshooting.html.erb
+++ b/source/categories/_build_troubleshooting.html.erb
@@ -23,6 +23,8 @@
   <a href="/docs/class-require-fails.html" class="link-reset db normal black-50 hover-black-80 pv1">Requiring a class file fails</a>
   <div hidden="true" class="article-key">Selenium tests are unable to obtain connection to Firefox</div>
   <a href="/docs/selenium-unable-to-obtain-connection.html" class="link-reset db normal black-50 hover-black-80 pv1">Selenium tests are unable to obtain connection to Firefox</a>
+  <div hidden="true" class="article-key">How to update Chrome on Semaphore?</div>
+  <a href="/docs/how-to-update-chrome.html" class="link-reset db normal black-50 hover-black-80 pv1">How to update Chrome on Semaphore?</a>
   <div hidden="true" class="article-key">Tests fail on Semaphore but pass locally</div>
   <a href="/docs/tests-fail-on-semaphore-but-pass-locally.html" class="link-reset db normal black-50 hover-black-80 pv1">Tests fail on Semaphore but pass locally</a>
   <div hidden="true" class="article-key">Tests or setup fail with "Real HTTP connections are disabled."</div>

--- a/source/docs/how-to-update-chrome.md.erb
+++ b/source/docs/how-to-update-chrome.md.erb
@@ -4,16 +4,8 @@ title: How to update Chrome on Semaphore?
 category: Build troubleshooting
 ---
 
-Software updates on Semaphore are provided with [regular platfrom updates](/docs/platform-updates.html)
-and every platform update includes the latest stable Chrome and ChromeDriver versions.
-
-Currently, Semaphore supports Chrome version <%= package_version("chrome") %>
-and ChromeDriver <%= package_version("chromedriver") %>.
-For the list of all pre-installed tools reffer to our
-[supported application stack](/docs/supported-stack.html) page.
-
 If your developement process depends on the latest Chrome version which is not pre-installed on Semaphore,
-add the following commands to the setup of the build
+you can install it by adding the following commands to the setup of the build:
 
 ```bash
 sudo touch /etc/apt/sources.list.d/google-chrome-source.list
@@ -24,22 +16,25 @@ These commands [cache](/docs/caching-between-builds.html) installations from APT
 To get more detailed informations about its options,
 refer to [this](/docs/how-to-install-dependency.html#caching-installations) page.
 
-When the `chromedriver-helper` gem is used in projects, 
-it's often configured to use the [latest available version of ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/downloads). 
-This can then cause an incompatibility issue (shown below), 
-indicating that the pre-installed Google Chrome version isn't supported.
+Software updates on Semaphore are provided with [regular platform updates](/docs/platform-updates.html).
+Also, every platform update comes with updated and compatible versions of ChromeDriver and Google Chrome stable.
 
-In this case, the `chromedriver-helper` gem overrides the pre-installed version,
-and the latest version is used instead of the included one.
+Semaphore currently supports Chrome <%= package_version("chrome") %>
+and ChromeDriver <%= package_version("chromedriver") %>.
+
+`chromedriver-helper` gem is often configured to use
+the [latest available version of ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/downloads). 
+This can lead to an incompatibility issue (shown below), 
+indicating that the pre-installed Google Chrome version isn't supported.
 
 ```bash
 session not created exception: Chrome version must be >= 65.0.3325.0 
 (Driver info: chromedriver=2.38.551591 (bcc4a2cdef0f6b942b2bb8049068f65340fa2a69)
 ```
 
-One of the following options can help when resolving this on Semaphore:
+In this case, the `chromedriver-helper` gem overrides the pre-installed version,
+and the latest version is used instead of the included one.
 
-- update Chrome in the Semaphore environment by adding aforementioned commands to the setup of the build. 
-- [configure](https://github.com/flavorjones/chromedriver-helper#specifying-a-version) `chromedriver-helper` gem to use a compatible ChromeDriver version (<%= package_version("chromedriver") %>)
+Besides updating Google Chrome, you can also [configure](https://github.com/flavorjones/chromedriver-helper#specifying-a-version) `chromedriver-helper` gem to use a compatible ChromeDriver version (<%= package_version("chromedriver") %>)
 
 For the fastest feedback loop, you can try these steps while in an [SSH session](/docs/ssh-access-to-build-environment.html).

--- a/source/docs/how-to-update-chrome.md.erb
+++ b/source/docs/how-to-update-chrome.md.erb
@@ -1,0 +1,45 @@
+---
+layout: post
+title: How to update Chrome on Semaphore?
+category: Build troubleshooting
+---
+
+Software updates on Semaphore are provided with [regular platfrom updates](/docs/platform-updates.html)
+and every platform update includes the latest stable Chrome and ChromeDriver versions.
+
+Currently, Semaphore supports Chrome version <%= package_version("chrome") %>
+and ChromeDriver <%= package_version("chromedriver") %>.
+For the list of all pre-installed tools reffer to our
+[supported application stack](/docs/supported-stack.html) page.
+
+If your developement process depends on the latest Chrome version which is not pre-installed on Semaphore,
+add the following commands to the setup of the build
+
+```bash
+sudo touch /etc/apt/sources.list.d/google-chrome-source.list
+install-package --update-new google-chrome-stable
+```
+
+These commands [cache](/docs/caching-between-builds.html) installations from APT with our `install-package` tool.
+To get more detailed informations about its options,
+refer to [this](/docs/how-to-install-dependency.html#caching-installations) page.
+
+When the `chromedriver-helper` gem is used in projects, 
+it's often configured to use the [latest available version of ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/downloads). 
+This can then cause an incompatibility issue (shown below), 
+indicating that the pre-installed Google Chrome version isn't supported.
+
+In this case, the `chromedriver-helper` gem overrides the pre-installed version,
+and the latest version is used instead of the included one.
+
+```bash
+session not created exception: Chrome version must be >= 65.0.3325.0 
+(Driver info: chromedriver=2.38.551591 (bcc4a2cdef0f6b942b2bb8049068f65340fa2a69)
+```
+
+One of the following options can help when resolving this on Semaphore:
+
+- update Chrome in the Semaphore environment by adding aforementioned commands to the setup of the build. 
+- [configure](https://github.com/flavorjones/chromedriver-helper#specifying-a-version) `chromedriver-helper` gem to use a compatible ChromeDriver version (<%= package_version("chromedriver") %>)
+
+For the fastest feedback loop, you can try these steps while in an [SSH session](/docs/ssh-access-to-build-environment.html).

--- a/source/docs/how-to-update-chrome.md.erb
+++ b/source/docs/how-to-update-chrome.md.erb
@@ -22,6 +22,8 @@ Also, every platform update comes with updated and compatible versions of Chrome
 Semaphore currently supports Chrome <%= package_version("chrome") %>
 and ChromeDriver <%= package_version("chromedriver") %>.
 
+# Common issues
+
 `chromedriver-helper` gem is often configured to use
 the [latest available version of ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/downloads). 
 This can lead to an incompatibility issue (shown below), 

--- a/source/docs/languages/javascript/custom-config-js.md
+++ b/source/docs/languages/javascript/custom-config-js.md
@@ -27,7 +27,7 @@ module.exports = {
 ```
 
 You can use credentials in `config.js` to instantiate
-[Sequelize](http://sequelizejs.com/):
+[Sequelize](https://github.com/sequelize/sequelize):
 
 ```javascript
 var Sequelize = require('sequelize')


### PR DESCRIPTION
This post describes how Chrome can be updated in the Semaphore environment with build commands.
It is mostly inspired by failed build reports for Ruby projects which use `chromedriver-helper` gem.