### PR TITLE
Add "create a Semaphore account" step to "Setting up Boosters" page

### DIFF
--- a/source/docs/setting-up-boosters.md.erb
+++ b/source/docs/setting-up-boosters.md.erb
@@ -12,12 +12,14 @@ tags:
 
 To set up RSpec Boosters, complete the following steps:
 
-1. Visit your project settings page.
+1. If you don't already have a Semaphore account, [create one for free](/users/sign_up) and add your project.
 
-2. Below your project commands, you will see the option to add new commands and
+2. Visit your project settings page.
+
+3. Below your project commands, you will see the option to add new commands and
    Boosters. Select **RSpec Booster**.
 
-3. Pick a branch and start a test build.
+4. Pick a branch and start a test build.
 
     Once Semaphore starts the build, everything will be sandboxed to this branch, so
 your project configuration will not be affected.
@@ -28,7 +30,7 @@ results as quickly as possible.
     Once the build is finished, Semaphore will recommend the optimal number of jobs
 required to make your build as fast as possible.
 
-4. Select the number of jobs that works best for you, and click on **Append
+5. Select the number of jobs that works best for you, and click on **Append
    parallel jobs**.
 
 Boosters will now automatically parallelize your RSpec test suite for each new
@@ -38,12 +40,14 @@ build.
 
 To set up Cucumber Boosters, complete the following steps:
 
-1. Visit your project settings page.
+1. If you don't already have a Semaphore account, [create one for free](/users/sign_up) and add your project.
 
-2. Below your project commands, you will see the option to add new commands and
+2. Visit your project settings page.
+
+3. Below your project commands, you will see the option to add new commands and
    Boosters. Select **Cucumber Booster**.
 
-3. Pick a branch and start a test build.
+4. Pick a branch and start a test build.
 
     Once Semaphore starts the build, everything will be sandboxed to this branch, so
 your project configuration will not be affected.
@@ -54,7 +58,7 @@ results as quickly as possible.
     Once the build is finished, Semaphore will recommend the optimal number of jobs
 required to make your build as fast as possible.
 
-4. Select the number of jobs that works best for you, and click on **Append
+5. Select the number of jobs that works best for you, and click on **Append
    parallel jobs**.
 
 Boosters will now automatically parallelize your RSpec test suite for each new


### PR DESCRIPTION
We’ll link this page from the Boosters lander, so adding a step to
create an account for non-user visitors’ sake.