### PR TITLE
Edit info on MacOS and iOS support

### DIFF
--- a/source/docs/supported-stack.md.erb
+++ b/source/docs/supported-stack.md.erb
@@ -12,11 +12,6 @@ difference between platform types.
 The timezone in the Semaphore environment is set to UTC. To find out how to change
 this value visit [this page](/docs/how-to-change-timezone.html).
 
-__Note:__
-
-MacOS and iOS will be supported in [Semaphore 2.0](https://semaphoreci.com/v2-is-coming).
-
-
 ## <a name="platform-types" href="#platform-types">Platform types</a>
 
 - [Standard](#standard-platform)
@@ -177,3 +172,7 @@ Test frameworks known to be used by our users includes:
 * pytest
 
 Note that these are simply a reflection of the whole supported stack.
+
+### <a name="macos-ios" href="#macos-ios">MacOS and iOS</a>
+
+MacOS and iOS will be supported in [Semaphore 2.0](https://semaphoreci.com/product).


### PR DESCRIPTION
Added a subheading and changed the link from beta to semaphoreci/product