### PR TITLE
Downcase TOC links

### DIFF
--- a/source/cli.rb
+++ b/source/cli.rb
@@ -19,7 +19,7 @@ module CLI
   def self.toc(namespace)
     list = all_commands_in_namespace(namespace).map do |cmd|
       title = cmd["desc"].capitalize
-      href = cmd["desc"].split(" ").join("-")
+      href = cmd["desc"].split(" ").map(&:downcase).join("-")
 
       "<li><a href='##{href}'>#{title}</a></li>"
     end


### PR DESCRIPTION
For some reason, the link checker got more pedantic than before.

fixes https://github.com/renderedtext/issues/issues/1246