### PR TITLE
Adding index for swifttype

### DIFF
--- a/source/layout.html.erb
+++ b/source/layout.html.erb
@@ -6,6 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex">
+    <meta name="st:robots" content="follow, index">
 
     <% if content_for?(:title) %>
       <title><%= yield_content :title %> - Semaphore</title>


### PR DESCRIPTION
No index rule broke swifttype search. 
Adding new tag to overwrite it in the case of search.
https://github.com/renderedtext/tasks/issues/848